### PR TITLE
修复两处可能的 panic

### DIFF
--- a/plugin/go/postgresqlWeakPass.go
+++ b/plugin/go/postgresqlWeakPass.go
@@ -3,6 +3,7 @@ package goplugin
 import (
 	"database/sql"
 	"fmt"
+	"github.com/opensec-cn/kunpeng/util"
 	"strings"
 
 	_ "github.com/lib/pq"
@@ -42,11 +43,15 @@ func (d *postgresqlWeakPass) Check(netloc string, meta plugin.TaskMeta) (b bool)
 	userList := []string{
 		"postgres", "admin",
 	}
+	host, port := util.ParseNetLoc(netloc)
+	if port == 0 {
+		port = 5432
+	}
 	for _, user := range userList {
 		for _, pass := range meta.PassList {
 			pass = strings.Replace(pass, "{user}", user, -1)
-			connStr := fmt.Sprintf("host=%s port=%s user=%s password=%s sslmode=disable connect_timeout=%d",
-				strings.Split(netloc, ":")[0], strings.Split(netloc, ":")[1], user, pass, Config.Timeout)
+			connStr := fmt.Sprintf("host=%s port=%d user=%s password=%s sslmode=disable connect_timeout=%d",
+				host, port, user, pass, Config.Timeout)
 			db, err := sql.Open("postgres", connStr)
 			err = db.Ping()
 			if err == nil {

--- a/plugin/go/smbWeakPass.go
+++ b/plugin/go/smbWeakPass.go
@@ -2,6 +2,7 @@ package goplugin
 
 import (
 	"fmt"
+	"github.com/opensec-cn/kunpeng/util"
 	"strings"
 
 	"github.com/opensec-cn/kunpeng/plugin"
@@ -57,12 +58,16 @@ func (d *smbWeakPass) Check(netloc string, meta plugin.TaskMeta) (b bool) {
 		d.result = append(d.result, result)
 		return true
 	}
+	host, port := util.ParseNetLoc(netloc)
+	if port == 0 {
+		port = 445
+	}
 	for _, user := range userList {
 		for _, pass := range meta.PassList {
 			pass = strings.Replace(pass, "{user}", user, -1)
 			options := smb.Options{
-				Host:        strings.Split(netloc, ":")[0],
-				Port:        445,
+				Host:        host,
+				Port:        port,
 				User:        user,
 				Domain:      "",
 				Workstation: "workgroup",

--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -3,12 +3,11 @@ package plugin
 
 import (
 	"fmt"
+	. "github.com/opensec-cn/kunpeng/config"
+	"github.com/opensec-cn/kunpeng/util"
 	"sort"
 	"strconv"
 	"strings"
-
-	. "github.com/opensec-cn/kunpeng/config"
-	"github.com/opensec-cn/kunpeng/util"
 )
 
 // GoPlugins GO插件集

--- a/util/fun.go
+++ b/util/fun.go
@@ -8,6 +8,8 @@ import (
 	"log"
 	"math/rand"
 	"regexp"
+	"strconv"
+	"strings"
 	"time"
 )
 
@@ -60,4 +62,17 @@ func InArray(list []string, value string, regex bool) bool {
 		}
 	}
 	return false
+}
+
+// ParseNetloc 把 netloc 拆分为 host 和 port, 如果有的话
+func ParseNetLoc(netloc string) (host string, port int) {
+	results := strings.SplitN(netloc, ":", 2)
+	if len(results) == 1 {
+		return results[0],  0
+	}
+	port, err := strconv.Atoi(results[1])
+	if err != nil {
+		return results[0], 0
+	}
+	return results[0], port
 }


### PR DESCRIPTION
虽然 service 的情况下，输入的格式应该是 `host:port`, 但如果输入的只有 host， 也不应该发生 panic。 