### PR TITLE
扫描日志的获取

### DIFF
--- a/example/call_so_test.lua
+++ b/example/call_so_test.lua
@@ -34,7 +34,20 @@ local result_str = ffi.string(kunpeng.Check(taskArg))
 
 print(result_str)
 
+
+--- 测试logBuffer 的内容返回
+kunpeng.StartBuffer()
+local result_str = ffi.string(kunpeng.Check(taskArg))
+local scan_log = ffi.string(kunpeng.BufferContent(ffi.cast('char *',"")))
+print("result:")
+print(result_str)
+print("scan_log:")
+print(scan_log)
+
+
+
 --- 测试StartWebServer 
 kunpeng.StartWebServer( ffi.cast('char *',"0.0.0.0:3000") )
 io.stdin:read("*line")
+
 

--- a/main.go
+++ b/main.go
@@ -92,6 +92,16 @@ func GetVersion() *C.char {
 	return C.CString(VERSION)
 }
 
+//export StartBuffer
+func StartBuffer() {
+	util.Logger.StartBuffer()
+}
+
+//export BufferContent
+func BufferContent(sep *C.char) *C.char {
+	return C.CString(util.Logger.BufferContent(C.GoString(sep)))
+}
+
 var Greeter greeting
 
 func main() {}

--- a/util/log.go
+++ b/util/log.go
@@ -1,17 +1,25 @@
 package util
 
 import (
+	"fmt"
 	"log"
 	"os"
+	"strings"
 
 	"github.com/opensec-cn/kunpeng/config"
 )
 
 type logger struct {
-	info    *log.Logger
-	warning *log.Logger
-	err     *log.Logger
+	info         *log.Logger
+	warning      *log.Logger
+	err          *log.Logger
+	bufferStart  bool
+	buffer       []string
+	bufferLogLen int
 }
+
+//最大buffer可以放的字符串长度
+const maxBufferLogLen = 4096
 
 // Logger 日志打印
 var Logger logger
@@ -20,24 +28,59 @@ func init() {
 	Logger.info = log.New(os.Stdout, "[info] ", log.Ltime|log.Lshortfile)
 	Logger.warning = log.New(os.Stdout, "[warning] ", log.Ltime|log.Lshortfile)
 	Logger.err = log.New(os.Stderr, "[error] ", log.Ltime|log.Lshortfile)
+	Logger.buffer = make([]string, 0, 0)
+	Logger.bufferStart = false
+	Logger.bufferLogLen = 0
 }
 
 func (l *logger) Println(logs ...interface{}) {
 	l.info.Println(logs)
+	l.Buffer(logs)
 }
 
 func (l *logger) Info(logs ...interface{}) {
+	l.Buffer(logs)
 	if config.Debug == true {
 		l.info.Println(logs)
 	}
 }
 func (l *logger) Warning(logs ...interface{}) {
+	l.Buffer(logs)
 	if config.Debug == true {
 		l.warning.Println(logs)
 	}
 }
 func (l *logger) Error(logs ...interface{}) {
+	l.Buffer(logs)
 	if config.Debug == true {
 		l.err.Println(logs)
 	}
+}
+
+//缓存所有的log数据到一个切片当中，用来返回给调用的第三方
+func (l *logger) Buffer(logs ...interface{}) {
+	if l.bufferStart {
+		//为防止内存泄露,加上了最大长度限制
+		if l.bufferLogLen <= maxBufferLogLen {
+			bufferMessage := fmt.Sprintln(logs)
+			l.buffer = append(l.buffer, bufferMessage)
+			l.bufferLogLen += len(bufferMessage)
+		}
+	}
+}
+
+//开启缓存
+func (l *logger) StartBuffer() {
+	l.bufferStart = true
+}
+
+//完成两个功能
+//重置归位，释放使用的内存
+//返回buffer当中的内容，用 sep 连接起来
+func (l *logger) BufferContent(sep string) string {
+	message := strings.Join(l.buffer, sep)
+	l.buffer = make([]string, 0, 0)
+	l.bufferStart = false
+	l.bufferLogLen = 0
+	return message
 }


### PR DESCRIPTION
StartBuffer 来开启一个 slice 缓存。
之后,所有的log 信息都会存储到slice中 （最大存储的字符数为 4096）
最后通过 BufferContent 来获取slice 中的内容，并将对应缓存清零。

调用的例子 可以参看 :  call_so_test.lua 

