### PR TITLE
fix go/struts2-045 plugin return error bug

### DIFF
--- a/plugin/go/struts2-045.go
+++ b/plugin/go/struts2-045.go
@@ -50,8 +50,8 @@ func (d *struts2_45) Check(URL string, meta plugin.TaskMeta) (b bool) {
 	}
 	if strings.Contains(resp.ResponseRaw, "[safetest]") {
 		result := d.info
-		result.Response = resp.RequestRaw
-		result.Request = resp.ResponseRaw
+		result.Response = resp.ResponseRaw
+		result.Request = resp.RequestRaw
 		d.result = append(d.result, result)
 		return true
 	}


### PR DESCRIPTION
Error code position:
https://github.com/opensec-cn/kunpeng/blob/master/plugin/go/struts2-045.go#L53-L54

`resp.RequestRaw` should be assigned to `result.Request` rather than `result.Response`.